### PR TITLE
feat: preview gfm breaks

### DIFF
--- a/src/components/MarkdownPreview.tsx
+++ b/src/components/MarkdownPreview.tsx
@@ -6,17 +6,6 @@ import Prism from "prismjs";
 import "github-markdown-css";
 import "prismjs/themes/prism.css";
 
-marked.setOptions({
-  highlight(code, lang) {
-    if (!lang) {
-      return code;
-    }
-
-    const language = Prism.languages[lang] ?? Prism.languages.markup;
-    return Prism.highlight(code, language, lang);
-  }
-});
-
 const MarkdownContent = styled.div``;
 
 type Props = {
@@ -36,7 +25,17 @@ function MarkdownPreview(props: Props = {}) {
     ...restProps
   } = props;
 
-  const html = marked.parse(content);
+  const html = marked.parse(content, {
+    breaks: true,
+    highlight(code, lang) {
+      if (!lang) {
+        return code;
+      }
+
+      const language = Prism.languages[lang] ?? Prism.languages.markup;
+      return Prism.highlight(code, language, lang);
+    }
+  });
 
   const cleanHtml = sanitizeHtml(html, {
     allowedTags,


### PR DESCRIPTION
refactor: move options to parse, no need `setOptions`

<img width="301" alt="image" src="https://user-images.githubusercontent.com/19513289/168945166-bf8e374d-f29c-43eb-ad53-9774a7e59f22.png">
